### PR TITLE
PAN-30 Social login & registration tracking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=find_packages('src', exclude=['example', 'example.*']),
     package_dir={'' : 'src'},
     include_package_data=True,
-    version='1.0.1',
+    version='1.0.2',
     description='RPX auth support for django',
     author='Michael Huynh',
     author_email='mike@mikexstudios.com',

--- a/src/django_rpx_plus/signals.py
+++ b/src/django_rpx_plus/signals.py
@@ -2,4 +2,5 @@ from django.dispatch import Signal
 
 #Often, one would like to perform some action (like sending a confirmation email)
 #upon successful user registration.
-registration_successful = Signal(providing_args = ['user'])
+registration_successful = Signal(providing_args = ['request', 'user'])
+rpx_login = Signal(providing_args=['request', 'success'])


### PR DESCRIPTION
**Description**

We need to be able to track whenever an user registered or logged in from the social auth.

`rpx` library currently has a signal for registration, but it does not send the request through - if we want to listen for this signal and track the event from there, we need the request to retrieve the tracker.

For logins, either success or fail ones, there is no signal, so a signal was created to handle these cases.