### PR TITLE
Resolved a deprecation warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=find_packages('src', exclude=['example', 'example.*']),
     package_dir={'' : 'src'},
     include_package_data=True,
-    version='1.0.2',
+    version='1.0.3',
     description='RPX auth support for django',
     author='Michael Huynh',
     author_email='mike@mikexstudios.com',

--- a/src/django_rpx_plus/forms.py
+++ b/src/django_rpx_plus/forms.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 
 class RegisterForm(forms.Form):
     username = forms.RegexField(regex=r'^\w+$', max_length = 30, label = _('Username'),
-                                error_message = _('The username must contain only letters, numbers and underscores.'))
+                                error_messages={'invalid':_('The username must contain only letters, numbers and underscores.')})
     email = forms.EmailField(label = _('Email Address'), max_length = 254)
 
     def clean_username(self):


### PR DESCRIPTION
Same behaviour, new arguments. Ref https://code.djangoproject.com/ticket/23151

Fixes this deprecation warning:
```
.../lib/python2.7/site-packages/django_rpx_plus/forms.py:8: RemovedInDjango110Warning: The 'error_message' argument is deprecated. Use Field.error_messages['invalid'] instead.
  error_message = _('The username must contain only letters, numbers and underscores.'))
```
This does **not** make the package compatible with Django 1.11.

